### PR TITLE
Change Control Manager Script Examples

### DIFF
--- a/CloudVision_ChangeControlManager_Scripts/Installing CCM Scripts.md
+++ b/CloudVision_ChangeControlManager_Scripts/Installing CCM Scripts.md
@@ -1,0 +1,42 @@
+# Installing CCM Scripts
+
+CVP requires two files for Custom Scripts:
+   - Python script file
+   - Yaml configuration file
+
+**Change Control Script**
+This script will be associated with the device(s) modified in the Change Control.
+The device information is available as globalVariables (CVP_IP,  CVP_MAC, CVP_SERIAL)
+The information for the user executing the Change Control is available as global variables(CVP_USERNAME, CVP_PASSWORD and CVP_SESSION_ID).
+The script can use the Rest Client library and Device library to extend its functionality.  
+CVP audit logging is available within scripts using the ‘alog()’ function
+
+**Change Control Script Config YAML**
+The YAML config file containing parameters:
+Name - the script name used in identifying the specific script to add to Change Controls.
+Args - optional parameter which contains a list of static arguments which can be passed to the script.
+
+**Installing and Checking Scripts**
+Copy the script and Config file to the CVP server
+
+   scp ./{{name of script}}.* root@{{CVP server name}}:/home/cvpadmin/
+
+Test the Script on the CVP Server
+
+login to the CVP server as root
+   cd /home/cvpadmin
+   /cvpi/tools/script-util test -device {{macAddress of Test Switch}} -config ./{{script name}}.yaml -path ./{{script name}}.py -user {{cvp username}} -passwd {{cvp user password}}
+
+should result in something similar to:
+
+   I0917 13:16:32.530398   31009 dial.go:123] connecting to {localhost:9900 static:///localhost:9900}...
+   I0917 13:16:32.962890   31009 script.go:343] script succeeded. Ouput:
+
+Upload script and config file to the CVP Application:
+
+   /cvpi/tools/script-util upload -config ./{{script name}}.yaml -path ./{{script name}}.py
+
+should result in:
+
+   I0917 13:28:45.875159    2787 dial.go:123] connecting to {localhost:9900 static:///localhost:9900}...
+   script uploaded successfully!!

--- a/CloudVision_ChangeControlManager_Scripts/README.md
+++ b/CloudVision_ChangeControlManager_Scripts/README.md
@@ -1,0 +1,38 @@
+# CVP_CCM
+
+These scripts are to be used in the Change Management Workflow. They use various internal CVP libraries to execute tests on either Arista switches or Linux devices. If the tests are successful the scripts will exit cleanly otherwise they will raise an exception or assert error.
+
+**check_switchType**
+
+Change Control script that uses the arguments provided by check_switchType.yaml to check the switch type (model). The script uses the model description returned by the show version command and compares this to the switchType provided in the script arguments yaml file. The arguments in the yaml file are as follows:
+   switchType - required model name that the switch needs to be for the change workflow to progress
+
+The script uses the internal CVP library "Device" to access the eAPI interface on the target Arista EOS switch it then executes the "show version" and "show hostname" commands to gather the required information for the script. The script will fail if the switchType does not match the modelName in the show version return.
+
+**device_ping**
+
+Change Control script that uses the arguments provided by device_ping.yaml to check connectivity between a number of client devices and their targets. The arguments in the yaml file are as follows:
+   deviceList - list of Linux clients to ping the target list from
+   targetList - list of devices to ping from the Linux clients
+   passmark   - percentage of received pings required to Pass each ping test
+   failCount  - number of ping tests that can fail before the ping_device script fails
+   username   - username to access the Linux clients
+   password   - password to use to the client access devices
+   pingCount  - number of Pings to send from each client to each target
+   timeout    - time to wait for each ping process to complete, this prevents script from hanging if the pings
+                  fail or take too long
+
+The script uses paramiko to access each client using SSH and then executes a ping command to each target.
+
+**page_check**
+
+Change Control script that uses the arguments provided by page_check.yaml to check if a web page is reachable from a number of client devices. The arguments in the yaml file are as follows:
+   pageURL - the web page to access from the specified clients.
+   deviceList - a comma separated list of clients to check the web page from, note this not a yaml list but a
+                  comma separated text string.
+   failCount  - number of page reachability tests that can fail before the web_check script fails
+   username   - username to access the client devices
+   password   - password to use to the client access devices
+   timeout    - how long to wait for a response from the web page
+
+The script uses paramiko to access each client using SSH and then executes a curl command to reach the web page.

--- a/CloudVision_ChangeControlManager_Scripts/check_switchType.py
+++ b/CloudVision_ChangeControlManager_Scripts/check_switchType.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2019, Arista Networks
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#   Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+#   Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+#   Neither the name of Arista Networks nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+"""
+CCM Script - Check device Type
+Description - Simple CCM script to demonstrate functionality and application
+
+Notes -
+Global Variables available to script using cvplibrary
+   CVP_USERNAME - Username of the current user
+   CVP_PASSWORD - Password of the current user
+   CVP_IP - IP address of the current device
+   CVP_MAC - MAC of the current device
+   CVP_SERIAL - Serial number of the current device
+   CVP_SESSION_ID - Session id of current cvp user, this can be passed around to cvp api
+   SCRIPT_ARGS - A dictionary of arguments passed to the Script Action configured in associated yaml file
+
+Audit Logging function
+   alog(string) - alog function writes the string to the audit logs tagged with the specific change control
+   calling the script
+
+Smaple yaml file
+   name : check_switchType
+   args:
+      switchType : vEOS
+
+"""
+# Import required Librarys
+import json
+from cvplibrary.auditlogger import alog # CVP auit log function
+from cvplibrary import Device, CVPGlobalVariables, GlobalVariableNames # CVP Variables
+
+# Create Script variables
+ipAddress = CVPGlobalVariables.getValue( GlobalVariableNames.CVP_IP)
+scriptArgs = CVPGlobalVariables.getValue( GlobalVariableNames.SCRIPT_ARGS)
+
+# Write entry to Log
+alog("running show version from script to check switch type")
+# Connect to Device specified in Change Control
+switch = Device(ipAddress)
+# Run show commands on switch
+cmdOut = switch.runCmds(["show version","show hostname"])
+# Check if the switch type is correct
+if str(scriptArgs['switchType']) not in cmdOut[0]["response"]["modelName"]:
+    logTxt = "WARNING: switch %s is not a %s it is a %s" %(cmdOut[1]["response"]["hostname"],
+                                                  scriptArgs['switchType'],
+                                                  cmdOut[0]["response"]["modelName"])
+    alog(logTxt)
+    assert(False)
+else:
+    logTxt = "SUCCESS: switch %s is a %s" %(cmdOut[1]["response"]["hostname"],
+                                            cmdOut[0]["response"]["modelName"])
+    alog(logTxt)

--- a/CloudVision_ChangeControlManager_Scripts/check_switchType.yaml
+++ b/CloudVision_ChangeControlManager_Scripts/check_switchType.yaml
@@ -1,0 +1,3 @@
+name : check_switchType
+args:
+   switchType : vEOS

--- a/CloudVision_ChangeControlManager_Scripts/device_ping.py
+++ b/CloudVision_ChangeControlManager_Scripts/device_ping.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2019, Arista Networks
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#   Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+#   Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+#   Neither the name of Arista Networks nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+"""
+CCM Script - PIng Test Between 2 Devices
+Description - Simple CCM script to ping between two devices
+
+Notes -
+Global Variables available to script using cvplibrary
+   CVP_USERNAME - Username of the current user
+   CVP_PASSWORD - Password of the current user
+   CVP_IP - IP address of the current device
+   CVP_MAC - MAC of the current device
+   CVP_SERIAL - Serial number of the current device
+   CVP_SESSION_ID - Session id of current cvp user, this can be passed around to cvp api
+   SCRIPT_ARGS - A dictionary of arguments passed to the Script Action configured in associated yaml file
+
+Audit Logging function
+   alog(string) - alog function writes the string to the audit logs tagged with the specific change control
+   calling the script
+
+Required Arguments
+   deviceList - list of Linux devices to ping from
+   targetList - list of devices to ping
+   passmark   - Percentage of recieved Pings required to Pass each Ping test
+   failCount  - Number of Ping Tests that can fail before ping_device fails
+   username   - Username to access devices
+   password   - Password to use to access devices
+   pingCount  - Number of Pings to send
+   timeout    - Ping timeout
+
+Smaple yaml file
+   name : device_ping
+   args:
+    deviceList: "10.83.30.110,10.83.30.111,10.83.30.112,10.83.30.115"
+    targetList: "192.168.50.10,192.168.51.10,192.168.52.10,192.168.53.10"
+    passmark: 100
+    failCount: 1
+    username: 'username'
+    password: 'password'
+    pingCount: 5
+    timeout: 5
+
+"""
+# Import required CVP Libraries
+from cvplibrary.auditlogger import alog # CVP auit log function
+from cvplibrary import Device, CVPGlobalVariables, GlobalVariableNames # CVP Variables
+from cvplibrary.request_session import RequestSession
+
+# Import Python Libraries
+import paramiko
+import re
+
+# Check to see if this script is being tested or run in CVP
+test = False
+if not RequestSession.getSessionId():
+   test = True
+
+# Log message handling
+def outMsg(test,msgTxt):
+    """ Output log messages to stdout if testing
+      or CVP CC log if running in CVP
+    """
+    if test:
+        print(msgTxt)
+    else:
+        alog(msgTxt)
+
+# Create Script variables
+scriptArgs = CVPGlobalVariables.getValue( GlobalVariableNames.SCRIPT_ARGS)
+scriptArgs['deviceList']=re.split(',',scriptArgs['deviceList'])
+scriptArgs['targetList']=re.split(',',scriptArgs['targetList'])
+
+# Internal Variables
+host_port = 22
+passed = 0
+failed = 0
+
+# Write entry to Log
+outMsg(test, "device_ping - checking endpoint connectivity")
+
+# Intialise SSH
+ssh = paramiko.SSHClient()
+ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+# Start ping tests from devices in deviceList
+for device_ip in scriptArgs['deviceList']:
+    outMsg(test, "device_ping: Connecting to %s" %device_ip)
+    ssh.connect(device_ip, port=host_port, username=scriptArgs['username'], password=scriptArgs['password'])
+    for target in scriptArgs['targetList']:
+        stdin, stdout, stderr = ssh.exec_command('ping -c %s -w %s %s' %(scriptArgs['pingCount'],
+                                                                         scriptArgs['timeout'],target))
+        output = stdout.readlines()
+        # Extract Ping results
+        ping_stats = re.split(',', output[-2])
+        ping_tx = re.split('(\d+)',ping_stats[0])[1]
+        ping_rx = re.split('(\d+)',ping_stats[1])[1]
+        ping_pkl = re.split('(\d+)',ping_stats[2])[1]
+        ping_pkr = 100-int(ping_pkl)
+        # Check Ping Results and Log them
+        if int(ping_pkr) >= int(scriptArgs['passmark']):
+            outMsg(test, "device_ping: Ping form %s to %s - Pass" %(device_ip, target))
+            passed += 1
+        else:
+            outMsg(test, "device_ping: Ping form %s to %s - Failed" %(device_ip, target))
+            failed += 1
+    ssh.close()
+# If number of Ping tests that failed exceeds failCount
+# fail the whole test
+if int(scriptArgs['failCount']) > failed:
+    outMsg(test, "device_ping: Passed - Number of failures must be less than %s. %s device(s) recieved the required number of pings" %(scriptArgs['failCount'],passed))
+else:
+    outMsg(test, "device_ping: - Failed Number of failures must be less than %s. %s device(s) did not recieve the required number of pings" %(scriptArgs['failCount'],failed))
+    if not test:
+      raise UserWarning("device_ping: Failed")

--- a/CloudVision_ChangeControlManager_Scripts/device_ping.yaml
+++ b/CloudVision_ChangeControlManager_Scripts/device_ping.yaml
@@ -1,0 +1,10 @@
+name : device_ping
+args:
+  deviceList: 10.83.30.110,10.83.30.111,10.83.30.112,10.83.30.115
+  targetList: 192.168.50.10,192.168.51.10,192.168.52.10,192.168.53.10
+  passmark: 100
+  failCount: 3
+  pingCount: 5
+  timeout: 1
+  username: username
+  password: password

--- a/CloudVision_ChangeControlManager_Scripts/page_check.py
+++ b/CloudVision_ChangeControlManager_Scripts/page_check.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2019, Arista Networks
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#   Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+#   Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+#   Neither the name of Arista Networks nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+"""
+CCCM Script - Check for avialable web page url
+Description - Simple CCM script to check for the prescence of a web page
+
+Notes -
+Global Variables available to script using cvplibrary
+   CVP_USERNAME - Username of the current user
+   CVP_PASSWORD - Password of the current user
+   CVP_IP - IP address of the current device
+   CVP_MAC - MAC of the current device
+   CVP_SERIAL - Serial number of the current device
+   CVP_SESSION_ID - Session id of current cvp user, this can be passed around to cvp api
+   SCRIPT_ARGS - A dictionary of arguments passed to the Script Action configured in associated yaml file
+
+Audit Logging function
+   alog(string) - alog function writes the string to the audit logs tagged with the specific change control
+   calling the script
+
+Required Arguments
+   pageURL - web page to look for
+   deviceList - list of devices to check from
+   failCount  - Number of Page Tests that can fail before web_check fails
+   username   - Username to access devices
+   password   - Password to use to access devices
+   timeout    - How long to wait for a response
+
+Smaple yaml file
+   name : page_check
+   args:
+    deviceList: "10.83.30.110,10.83.30.111,10.83.30.112,10.83.30.115"
+    pageURL: "https://10.83.30.100/cv"
+    failCount: 2
+    username: 'username'
+    password: 'password'
+    timeout: 1
+
+"""
+# Import required CVP Libraries
+from cvplibrary.auditlogger import alog # CVP auit log function
+from cvplibrary import Device, CVPGlobalVariables, GlobalVariableNames # CVP Variables
+from cvplibrary.request_session import RequestSession
+
+# Import Python Libraries
+import paramiko
+import re
+
+# Check to see if this script is being tested or run in CVP
+test = False
+if not RequestSession.getSessionId():
+   test = True
+
+# Log message handling
+def outMsg(test,msgTxt):
+    """ Output log messages to stdout if testing
+      or CVP CC log if running in CVP
+    """
+    if test:
+        print(msgTxt)
+    else:
+        alog(msgTxt)
+
+# Create Script variables
+scriptArgs = CVPGlobalVariables.getValue( GlobalVariableNames.SCRIPT_ARGS)
+scriptArgs['deviceList']=re.split(',',scriptArgs['deviceList'])
+
+# Internal Variables
+host_port = 22
+passed = 0
+failed = 0
+
+# Write entry to Log
+outMsg(test, "page_check - check Web Page connectivity")
+
+# Intialise SSH
+ssh = paramiko.SSHClient()
+ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+# Start ping tests from devices in deviceList
+for device_ip in scriptArgs['deviceList']:
+   outMsg(test, "page_check: Connecting to %s" %device_ip)
+   ssh.connect(device_ip, port=host_port, username=scriptArgs['username'], password=scriptArgs['password'])
+   stdin, stdout, stderr = ssh.exec_command('curl --insecure -I -m %s %s' %(scriptArgs['timeout'],scriptArgs['pageURL']))
+   output = stdout.readlines()
+   error = stderr.readlines()
+   if "Failed" in str(error[-1]) or "Error" in str(error[-1]):
+      outMsg(test, "page_check: Access form %s to %s: Failed (1)" %(device_ip, scriptArgs['pageURL']))
+      outMsg(test,"page_check: %s" %error[-1])
+      failed += 1
+   else:
+      if "200 OK" in output[0]:
+         outMsg(test, "page_check: Access form %s to %s: Pass" %(device_ip, scriptArgs['pageURL']))
+         passed += 1
+      else:
+         outMsg(test, "page_check: Access form %s to %s: Failed (2)" %(device_ip, scriptArgs['pageURL']))
+         outMsg(test,"page_check: %s" %output[0])
+         failed += 1
+   ssh.close()
+# If number of Page tests that failed exceeds failCount
+# fail the whole test
+if int(scriptArgs['failCount']) > failed:
+   outMsg(test, "page_check: Passed - Number of failures must be less than %s. %s devices can access %s" %(scriptArgs['failCount'],
+                                                                                              passed,scriptArgs['pageURL']))
+else:
+   outMsg(test, "page_check: Failed - Number of failures must be less than %s. %s devices were not able to access %s" %(scriptArgs['failCount'],
+                                                                                                                         failed,scriptArgs['pageURL']))
+   if not test:
+      raise UserWarning("page_check: Failed")

--- a/CloudVision_ChangeControlManager_Scripts/page_check.yaml
+++ b/CloudVision_ChangeControlManager_Scripts/page_check.yaml
@@ -1,0 +1,8 @@
+name: page_check
+args:
+   deviceList: 10.83.30.110,10.83.30.111,10.83.30.112,10.83.30.115
+   pageURL: https://10.83.30.100
+   failCount: 2
+   timeout: 1
+   username: username
+   password: password


### PR DESCRIPTION
These scripts are to be used in the Change Management Workflow. They use various internal CVP libraries to execute tests on either Arista switches or Linux devices. If the tests are successful the scripts will exit cleanly otherwise they will raise an exception or assert error.